### PR TITLE
R&D for elasticsearch upgrade.

### DIFF
--- a/dcc-release-core/src/main/java/org/icgc/dcc/release/core/util/Configurations.java
+++ b/dcc-release-core/src/main/java/org/icgc/dcc/release/core/util/Configurations.java
@@ -17,21 +17,13 @@
  */
 package org.icgc.dcc.release.core.util;
 
-import static com.google.common.base.Strings.isNullOrEmpty;
-import static com.google.common.io.Files.copy;
-import static com.google.common.io.Resources.asByteSource;
-import static com.google.common.io.Resources.getResource;
-import static lombok.AccessLevel.PRIVATE;
-
-import java.io.File;
-import java.util.Map;
-
+import com.google.common.collect.ImmutableMap;
+import com.google.common.io.Files;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
 import lombok.SneakyThrows;
-import lombok.val;
 import lombok.extern.slf4j.Slf4j;
-
+import lombok.val;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.io.compress.CompressionCodec;
 import org.apache.hadoop.mapred.JobConf;
@@ -39,7 +31,13 @@ import org.apache.spark.SparkConf;
 import org.apache.spark.api.java.JavaPairRDD;
 import org.apache.spark.api.java.JavaRDD;
 
-import com.google.common.collect.ImmutableMap;
+import java.io.File;
+import java.util.Map;
+
+import static com.google.common.base.Strings.isNullOrEmpty;
+import static com.google.common.io.Resources.asByteSource;
+import static com.google.common.io.Resources.getResource;
+import static lombok.AccessLevel.PRIVATE;
 
 @Slf4j
 @NoArgsConstructor(access = PRIVATE)
@@ -97,7 +95,7 @@ public final class Configurations {
   private static void copyConfig(File configFile) {
     val configLocation = getResource(SCHEDULER_CONFIG);
     log.debug("Config location: {}", configLocation);
-    copy(asByteSource(configLocation), configFile);
+    asByteSource(configLocation).copyTo(Files.asByteSink(configFile));
   }
 
 }

--- a/dcc-release-job/dcc-release-job-index/pom.xml
+++ b/dcc-release-job/dcc-release-job-index/pom.xml
@@ -42,9 +42,15 @@ ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF S
     <dependency>
       <groupId>org.elasticsearch</groupId>
       <artifactId>elasticsearch</artifactId>
+      <version>2.4.0</version>
     </dependency>
 
     <!-- JSON -->
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-core</artifactId>
+      <version>2.6.7</version>
+    </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.dataformat</groupId>
       <artifactId>jackson-dataformat-smile</artifactId>

--- a/dcc-release-job/dcc-release-job-index/src/main/java/org/icgc/dcc/release/job/index/io/ClusterStateVerifier.java
+++ b/dcc-release-job/dcc-release-job-index/src/main/java/org/icgc/dcc/release/job/index/io/ClusterStateVerifier.java
@@ -17,21 +17,20 @@
  */
 package org.icgc.dcc.release.job.index.io;
 
-import static com.google.common.base.Preconditions.checkState;
-import static com.google.common.base.Throwables.propagate;
-import static java.util.concurrent.TimeUnit.SECONDS;
-import static org.elasticsearch.action.admin.cluster.health.ClusterHealthStatus.GREEN;
+import lombok.RequiredArgsConstructor;
+import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
+import lombok.val;
+import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.client.Client;
+import org.elasticsearch.cluster.health.ClusterHealthStatus;
 
 import java.util.concurrent.TimeUnit;
 
-import lombok.RequiredArgsConstructor;
-import lombok.SneakyThrows;
-import lombok.val;
-import lombok.extern.slf4j.Slf4j;
-
-import org.elasticsearch.ElasticsearchException;
-import org.elasticsearch.action.admin.cluster.health.ClusterHealthStatus;
-import org.elasticsearch.client.Client;
+import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.base.Throwables.propagate;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.elasticsearch.cluster.health.ClusterHealthStatus.GREEN;
 
 @Slf4j
 @RequiredArgsConstructor

--- a/dcc-release-job/dcc-release-job-index/src/main/java/org/icgc/dcc/release/job/index/service/IndexService.java
+++ b/dcc-release-job/dcc-release-job-index/src/main/java/org/icgc/dcc/release/job/index/service/IndexService.java
@@ -17,24 +17,18 @@
  */
 package org.icgc.dcc.release.job.index.service;
 
-import static com.google.common.base.Preconditions.checkState;
-import static com.google.common.base.Strings.nullToEmpty;
-import static com.google.common.base.Strings.repeat;
-import static com.google.common.base.Throwables.propagate;
-import static com.google.common.collect.ImmutableList.copyOf;
-import static com.google.common.collect.ImmutableMap.of;
-import static com.google.common.collect.Iterables.toArray;
-import static com.google.common.io.Resources.getResource;
-import static java.lang.Boolean.FALSE;
-import static java.lang.Boolean.TRUE;
-import static java.lang.String.format;
-import static lombok.AccessLevel.PRIVATE;
-import static org.elasticsearch.client.Requests.deleteMappingRequest;
-import static org.icgc.dcc.common.core.dcc.Versions.getScmInfo;
-import static org.icgc.dcc.common.core.util.Formats.formatBytes;
-import static org.icgc.dcc.common.core.util.Formats.formatCount;
-import static org.icgc.dcc.common.core.util.stream.Collectors.toImmutableList;
-import static org.icgc.dcc.release.core.util.JacksonFactory.MAPPER;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import lombok.*;
+import lombok.extern.slf4j.Slf4j;
+import org.elasticsearch.client.Client;
+import org.elasticsearch.client.ClusterAdminClient;
+import org.elasticsearch.client.IndicesAdminClient;
+import org.icgc.dcc.release.core.document.DocumentType;
+import org.joda.time.DateTime;
 
 import java.io.Closeable;
 import java.io.IOException;
@@ -43,24 +37,21 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 
-import lombok.Getter;
-import lombok.NonNull;
-import lombok.RequiredArgsConstructor;
-import lombok.SneakyThrows;
-import lombok.val;
-import lombok.extern.slf4j.Slf4j;
-
-import org.elasticsearch.client.Client;
-import org.elasticsearch.client.ClusterAdminClient;
-import org.elasticsearch.client.IndicesAdminClient;
-import org.icgc.dcc.release.core.document.DocumentType;
-import org.joda.time.DateTime;
-
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
+import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.base.Strings.nullToEmpty;
+import static com.google.common.base.Strings.repeat;
+import static com.google.common.base.Throwables.propagate;
+import static com.google.common.collect.ImmutableList.copyOf;
+import static com.google.common.collect.ImmutableMap.of;
+import static com.google.common.io.Resources.getResource;
+import static java.lang.Boolean.FALSE;
+import static java.lang.Boolean.TRUE;
+import static java.lang.String.format;
+import static lombok.AccessLevel.PRIVATE;
+import static org.icgc.dcc.common.core.dcc.Versions.getScmInfo;
+import static org.icgc.dcc.common.core.util.Formats.formatBytes;
+import static org.icgc.dcc.common.core.util.Formats.formatCount;
+import static org.icgc.dcc.release.core.util.JacksonFactory.MAPPER;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -90,26 +81,12 @@ public class IndexService implements Closeable {
         .isExists();
 
     if (exists) {
-      if (isLoadAll(types)) {
-        log.info("Deleting index '{}'...", indexName);
-        checkState(client.prepareDelete(indexName)
-            .execute()
-            .actionGet()
-            .isAcknowledged(),
-            "Index '%s' deletion was not acknowledged", indexName);
-
-        // Partial load
-      } else {
-        log.info("Unfreezing index...");
-        unfreezeIndex(indexName);
-
-        log.info("Deleting types {}...", types);
-        deleteTypes(indexName, types);
-
-        log.info("Initializing types {}...", types);
-        initializeTypeMappings(indexName, types);
-        return;
-      }
+      log.info("Deleting index '{}'...", indexName);
+      checkState(client.prepareDelete(indexName)
+          .execute()
+          .actionGet()
+          .isAcknowledged(),
+          "Index '%s' deletion was not acknowledged", indexName);
     }
 
     try {
@@ -126,19 +103,6 @@ public class IndexService implements Closeable {
     } catch (Throwable t) {
       propagate(t);
     }
-  }
-
-  private void deleteTypes(String indexName, Set<DocumentType> types) {
-    val typeNames = types.stream()
-        .map(type -> type.getName())
-        .collect(toImmutableList());
-
-    val request = deleteMappingRequest(indexName).types(toArray(typeNames, String.class));
-    val deleted = getIndexClient()
-        .deleteMapping(request)
-        .actionGet()
-        .isAcknowledged();
-    checkState(deleted, "Types deletion was not acknowledged!");
   }
 
   @SneakyThrows
@@ -198,7 +162,7 @@ public class IndexService implements Closeable {
   public void optimizeIndex(@NonNull String indexName) {
     // Optimize the the index for faster search operations by reducing the number of segments by merging
     getIndexClient()
-        .prepareOptimize(indexName)
+        .prepareForceMerge(indexName)
         .setMaxNumSegments(1)
         .execute()
         .actionGet();
@@ -296,8 +260,8 @@ public class IndexService implements Closeable {
         .getState();
 
     val result = new ImmutableSet.Builder<String>();
-    for (val key : state.getMetaData().aliases().keys()) {
-      result.add(key.value);
+    for (val key : state.getMetaData().getAliasAndIndexLookup().keySet()) {
+      result.add(key);
     }
 
     return result.build();

--- a/dcc-release-job/dcc-release-job-index/src/main/java/org/icgc/dcc/release/job/index/service/IndexVerificationService.java
+++ b/dcc-release-job/dcc-release-job-index/src/main/java/org/icgc/dcc/release/job/index/service/IndexVerificationService.java
@@ -17,36 +17,22 @@
  */
 package org.icgc.dcc.release.job.index.service;
 
-import static java.lang.String.format;
-import static org.icgc.dcc.common.core.util.stream.Collectors.toImmutableList;
-import static org.icgc.dcc.common.core.util.stream.Collectors.toImmutableMap;
-import static org.icgc.dcc.release.core.document.DocumentType.DONOR_CENTRIC_TYPE;
-import static org.icgc.dcc.release.core.document.DocumentType.DONOR_TEXT_TYPE;
-import static org.icgc.dcc.release.core.document.DocumentType.DONOR_TYPE;
-import static org.icgc.dcc.release.core.document.DocumentType.DRUG_CENTRIC_TYPE;
-import static org.icgc.dcc.release.core.document.DocumentType.DRUG_TEXT_TYPE;
-import static org.icgc.dcc.release.core.document.DocumentType.GENE_CENTRIC_TYPE;
-import static org.icgc.dcc.release.core.document.DocumentType.GENE_SET_TEXT_TYPE;
-import static org.icgc.dcc.release.core.document.DocumentType.GENE_SET_TYPE;
-import static org.icgc.dcc.release.core.document.DocumentType.GENE_TEXT_TYPE;
-import static org.icgc.dcc.release.core.document.DocumentType.GENE_TYPE;
-import static org.icgc.dcc.release.core.document.DocumentType.MUTATION_CENTRIC_TYPE;
-import static org.icgc.dcc.release.core.document.DocumentType.MUTATION_TEXT_TYPE;
-import static org.icgc.dcc.release.core.document.DocumentType.PROJECT_TEXT_TYPE;
-import static org.icgc.dcc.release.core.document.DocumentType.PROJECT_TYPE;
+import com.google.common.collect.ImmutableSet;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import lombok.val;
+import org.elasticsearch.client.Client;
+import org.icgc.dcc.common.core.util.Joiners;
+import org.icgc.dcc.release.core.document.DocumentType;
 
 import java.util.Map;
 import java.util.Set;
 
-import lombok.NonNull;
-import lombok.RequiredArgsConstructor;
-import lombok.val;
-import lombok.extern.slf4j.Slf4j;
-
-import org.elasticsearch.client.Client;
-import org.elasticsearch.common.collect.ImmutableSet;
-import org.icgc.dcc.common.core.util.Joiners;
-import org.icgc.dcc.release.core.document.DocumentType;
+import static java.lang.String.format;
+import static org.icgc.dcc.common.core.util.stream.Collectors.toImmutableList;
+import static org.icgc.dcc.common.core.util.stream.Collectors.toImmutableMap;
+import static org.icgc.dcc.release.core.document.DocumentType.*;
 
 @Slf4j
 @RequiredArgsConstructor

--- a/dcc-release-job/dcc-release-job-index/src/test/java/org/icgc/dcc/release/job/index/core/IndexJobTest.java
+++ b/dcc-release-job/dcc-release-job-index/src/test/java/org/icgc/dcc/release/job/index/core/IndexJobTest.java
@@ -17,20 +17,10 @@
  */
 package org.icgc.dcc.release.job.index.core;
 
-import static com.google.common.base.Preconditions.checkState;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.icgc.dcc.release.job.index.factory.TransportClientFactory.newTransportClient;
-import static org.mockito.Mockito.mock;
-
-import java.io.File;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Table;
 import lombok.val;
-
 import org.elasticsearch.client.Client;
-import org.elasticsearch.index.query.FilterBuilders;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.icgc.dcc.common.core.model.FieldNames;
@@ -46,8 +36,15 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Table;
+import java.io.File;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static com.google.common.base.Preconditions.checkState;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.icgc.dcc.release.job.index.factory.TransportClientFactory.newTransportClient;
+import static org.mockito.Mockito.mock;
 
 public class IndexJobTest extends AbstractJobTest {
 
@@ -103,7 +100,7 @@ public class IndexJobTest extends AbstractJobTest {
   }
 
   private void verifyDrugSets(DocumentType type, String field, Optional<String> path, long expectedDocuments) {
-    val existsFilter = FilterBuilders.existsFilter(field);
+    val existsFilter = QueryBuilders.existsQuery(field);
     // Can't use val here. Lombok fails to infer the type correctly
     QueryBuilder query = path.isPresent() ?
         QueryBuilders.nestedQuery(path.get(), existsFilter) :
@@ -191,7 +188,7 @@ public class IndexJobTest extends AbstractJobTest {
         .prepareSearch(index)
         // .setTypes(DocumentType.DONOR_TYPE.getName())
         .setTypes("donor")
-        .setPostFilter(FilterBuilders.existsFilter("project"))
+        .setPostFilter(QueryBuilders.existsQuery("project"))
         .execute().actionGet().getHits().getTotalHits();
     assertThat(donorsWithProjectCount).isEqualTo(3L);
   }

--- a/dcc-release-resources/src/main/resources/org/icgc/dcc/release/resources/mappings/diagram.mapping.json
+++ b/dcc-release-resources/src/main/resources/org/icgc/dcc/release/resources/mappings/diagram.mapping.json
@@ -2,7 +2,6 @@
   "diagram":{
     "enabled":false,
     "_source":{
-      "compress":"true"
     },
     "_all":{
       "enabled":"false"

--- a/dcc-release-resources/src/main/resources/org/icgc/dcc/release/resources/mappings/donor-centric.mapping.json
+++ b/dcc-release-resources/src/main/resources/org/icgc/dcc/release/resources/mappings/donor-centric.mapping.json
@@ -1,7 +1,6 @@
 {
   "donor-centric":{
     "_source":{
-      "compress":"true",
       "excludes": ["gene.*"]
     },
     "_all":{

--- a/dcc-release-resources/src/main/resources/org/icgc/dcc/release/resources/mappings/donor-text.mapping.json
+++ b/dcc-release-resources/src/main/resources/org/icgc/dcc/release/resources/mappings/donor-text.mapping.json
@@ -4,7 +4,6 @@
       "enabled": "false"
     },
     "_source": {
-      "compress": "true"
     },
     "date_detection": "false",
     "dynamic_templates": [
@@ -31,6 +30,7 @@
             "index": "analyzed",
             "index_analyzer": "id_index",
             "search_analyzer": "id_search",
+            "analyzer": "id_search",
             "type": "string"
           },
           "search": {
@@ -52,6 +52,7 @@
             "index": "analyzed",
             "index_analyzer": "id_index",
             "search_analyzer": "id_search",
+            "analyzer": "id_search",
             "type": "string"
           },
           "search": {
@@ -73,6 +74,7 @@
             "index": "analyzed",
             "index_analyzer": "id_index",
             "search_analyzer": "id_search",
+            "analyzer": "id_search",
             "type": "string"
           },
           "search": {
@@ -94,6 +96,7 @@
             "index": "analyzed",
             "index_analyzer": "id_index",
             "search_analyzer": "id_search",
+            "analyzer": "id_search",
             "type": "string"
           },
           "search": {
@@ -115,6 +118,7 @@
             "index": "analyzed",
             "index_analyzer": "id_index",
             "search_analyzer": "id_search",
+            "analyzer": "id_search",
             "type": "string"
           },
           "search": {
@@ -136,6 +140,7 @@
             "index": "analyzed",
             "index_analyzer": "id_index",
             "search_analyzer": "id_search",
+            "analyzer": "id_search",
             "type": "string"
           },
           "search": {
@@ -157,6 +162,7 @@
             "index": "analyzed",
             "index_analyzer": "id_index",
             "search_analyzer": "id_search",
+            "analyzer": "id_search",
             "type": "string"
           },
           "search": {

--- a/dcc-release-resources/src/main/resources/org/icgc/dcc/release/resources/mappings/donor.mapping.json
+++ b/dcc-release-resources/src/main/resources/org/icgc/dcc/release/resources/mappings/donor.mapping.json
@@ -1,7 +1,6 @@
 {
   "donor":{
     "_source":{
-      "compress":"true"
     },
     "_all":{
       "enabled":"false"

--- a/dcc-release-resources/src/main/resources/org/icgc/dcc/release/resources/mappings/drug-centric.mapping.json
+++ b/dcc-release-resources/src/main/resources/org/icgc/dcc/release/resources/mappings/drug-centric.mapping.json
@@ -1,7 +1,6 @@
 {
   "drug-centric": {
     "_source": {
-      "compress": "true"
     },
     "_all": {
       "enabled": "false"

--- a/dcc-release-resources/src/main/resources/org/icgc/dcc/release/resources/mappings/drug-text.mapping.json
+++ b/dcc-release-resources/src/main/resources/org/icgc/dcc/release/resources/mappings/drug-text.mapping.json
@@ -4,7 +4,6 @@
       "enabled": "false"
     },
     "_source": {
-      "compress": "true"
     },
     "date_detection": "false",
     "dynamic_templates": [
@@ -47,6 +46,7 @@
             "index": "analyzed",
             "index_analyzer": "id_index",
             "search_analyzer": "id_search",
+            "analyzer": "id_search",
             "type": "string"
           },
           "search": {
@@ -68,6 +68,7 @@
             "index": "analyzed",
             "index_analyzer": "id_index",
             "search_analyzer": "id_search",
+            "analyzer": "id_search",
             "type": "string"
           },
           "search": {
@@ -89,6 +90,7 @@
             "index": "analyzed",
             "index_analyzer": "id_index",
             "search_analyzer": "id_search",
+            "analyzer": "id_search",
             "type": "string"
           },
           "search": {
@@ -110,6 +112,7 @@
             "index": "analyzed",
             "index_analyzer": "id_index",
             "search_analyzer": "id_search",
+            "analyzer": "id_search",
             "type": "string"
           },
           "search": {
@@ -131,6 +134,7 @@
             "index": "analyzed",
             "index_analyzer": "id_index",
             "search_analyzer": "id_search",
+            "analyzer": "id_search",
             "type": "string"
           },
           "search": {

--- a/dcc-release-resources/src/main/resources/org/icgc/dcc/release/resources/mappings/gene-centric.mapping.json
+++ b/dcc-release-resources/src/main/resources/org/icgc/dcc/release/resources/mappings/gene-centric.mapping.json
@@ -4,7 +4,6 @@
       "enabled": "false"
     },
     "_source": {
-      "compress": "true",
       "includes": [
           "_gene_id",
           "_summary._affected_donor_count",
@@ -51,7 +50,7 @@
           }
         }
       },
-      "project": {
+      "gc_project": {
         "type": "nested"
       }
     }

--- a/dcc-release-resources/src/main/resources/org/icgc/dcc/release/resources/mappings/gene-set-text.mapping.json
+++ b/dcc-release-resources/src/main/resources/org/icgc/dcc/release/resources/mappings/gene-set-text.mapping.json
@@ -4,7 +4,6 @@
       "enabled": "false"
     },
     "_source": {
-      "compress": "true"
     },
     "date_detection": "false",
     "dynamic_templates": [
@@ -31,6 +30,7 @@
             "index": "analyzed",
             "index_analyzer": "id_index",
             "search_analyzer": "id_search",
+            "analyzer": "id_search",
             "type": "string"
           },
           "search": {
@@ -52,6 +52,7 @@
             "index": "analyzed",
             "index_analyzer": "id_index",
             "search_analyzer": "id_search",
+            "analyzer": "id_search",
             "type": "string"
           },
           "search": {
@@ -75,6 +76,7 @@
             "index": "analyzed",
             "index_analyzer": "id_index",
             "search_analyzer": "id_search",
+            "analyzer": "id_search",
             "type": "string"
           },
           "search": {

--- a/dcc-release-resources/src/main/resources/org/icgc/dcc/release/resources/mappings/gene-set.mapping.json
+++ b/dcc-release-resources/src/main/resources/org/icgc/dcc/release/resources/mappings/gene-set.mapping.json
@@ -1,7 +1,6 @@
 {
   "gene-set": {
     "_source": {
-      "compress": "true"
     },
     "_all": {
       "enabled": "false"

--- a/dcc-release-resources/src/main/resources/org/icgc/dcc/release/resources/mappings/gene-text.mapping.json
+++ b/dcc-release-resources/src/main/resources/org/icgc/dcc/release/resources/mappings/gene-text.mapping.json
@@ -4,7 +4,6 @@
       "enabled": "false"
     },
     "_source": {
-      "compress": "true"
     },
     "date_detection": "false",
     "dynamic_templates": [
@@ -31,6 +30,7 @@
             "index": "analyzed",
             "index_analyzer": "id_index",
             "search_analyzer": "id_search",
+            "analyzer": "id_search",
             "type": "string"
           },
           "search": {
@@ -52,6 +52,7 @@
             "index": "analyzed",
             "index_analyzer": "id_index",
             "search_analyzer": "id_search",
+            "analyzer": "id_search",
             "type": "string"
           },
           "search": {
@@ -73,6 +74,7 @@
             "index": "analyzed",
             "index_analyzer": "id_index",
             "search_analyzer": "id_search",
+            "analyzer": "id_search",
             "type": "string"
           },
           "search": {
@@ -94,6 +96,7 @@
             "index": "analyzed",
             "index_analyzer": "id_index",
             "search_analyzer": "id_search",
+            "analyzer": "id_search",
             "type": "string"
           },
           "search": {
@@ -115,6 +118,7 @@
             "index": "analyzed",
             "index_analyzer": "id_index",
             "search_analyzer": "id_search",
+            "analyzer": "id_search",
             "type": "string"
           },
           "search": {

--- a/dcc-release-resources/src/main/resources/org/icgc/dcc/release/resources/mappings/gene.mapping.json
+++ b/dcc-release-resources/src/main/resources/org/icgc/dcc/release/resources/mappings/gene.mapping.json
@@ -2,7 +2,6 @@
   "gene":{
     "enabled":"false",
     "_source":{
-      "compress":"true"
     },
     "_all":{
       "enabled":"false"

--- a/dcc-release-resources/src/main/resources/org/icgc/dcc/release/resources/mappings/mutation-centric.mapping.json
+++ b/dcc-release-resources/src/main/resources/org/icgc/dcc/release/resources/mappings/mutation-centric.mapping.json
@@ -1,7 +1,6 @@
 {
   "mutation-centric":{
     "_source":{
-      "compress":"true"
     },
     "_all":{
       "enabled":"false"

--- a/dcc-release-resources/src/main/resources/org/icgc/dcc/release/resources/mappings/mutation-text.mapping.json
+++ b/dcc-release-resources/src/main/resources/org/icgc/dcc/release/resources/mappings/mutation-text.mapping.json
@@ -4,7 +4,6 @@
       "enabled": "false"
     },
     "_source": {
-      "compress": "true"
     },
     "date_detection": "false",
     "dynamic_templates": [
@@ -31,6 +30,7 @@
             "index": "analyzed",
             "index_analyzer": "id_index",
             "search_analyzer": "id_search",
+            "analyzer": "id_search",
             "type": "string"
           },
           "search": {
@@ -52,6 +52,7 @@
             "index": "analyzed",
             "index_analyzer": "id_index",
             "search_analyzer": "id_search",
+            "analyzer": "id_search",
             "type": "string"
           },
           "search": {
@@ -73,6 +74,7 @@
             "index": "analyzed",
             "index_analyzer": "id_index",
             "search_analyzer": "id_search",
+            "analyzer": "id_search",
             "type": "string"
           },
           "search": {

--- a/dcc-release-resources/src/main/resources/org/icgc/dcc/release/resources/mappings/observation-centric.mapping.json
+++ b/dcc-release-resources/src/main/resources/org/icgc/dcc/release/resources/mappings/observation-centric.mapping.json
@@ -1,7 +1,6 @@
 {
   "observation-centric": {
     "_source": {
-      "compress": "true",
       "excludes": [
         "project.primary_site",
         "donor.donor_sex",
@@ -36,7 +35,7 @@
       "donor": {
         "type": "nested"
       },
-      "project": {
+      "oc_project": {
         "type": "nested"
       },
       "ssm": {

--- a/dcc-release-resources/src/main/resources/org/icgc/dcc/release/resources/mappings/project-text.mapping.json
+++ b/dcc-release-resources/src/main/resources/org/icgc/dcc/release/resources/mappings/project-text.mapping.json
@@ -4,7 +4,6 @@
       "enabled": "false"
     },
     "_source": {
-      "compress": "true"
     },
     "date_detection": "false",
     "dynamic_templates": [
@@ -31,6 +30,7 @@
             "index": "analyzed",
             "index_analyzer": "id_index",
             "search_analyzer": "id_search",
+            "analyzer": "id_search",
             "type": "string"
           },
           "search": {
@@ -52,6 +52,7 @@
             "index": "analyzed",
             "index_analyzer": "id_index",
             "search_analyzer": "id_search",
+            "analyzer": "id_search",
             "type": "string"
           },
           "search": {
@@ -73,6 +74,7 @@
             "index": "analyzed",
             "index_analyzer": "id_index",
             "search_analyzer": "id_search",
+            "analyzer": "id_search",
             "type": "string"
           },
           "search": {
@@ -94,6 +96,7 @@
             "index": "analyzed",
             "index_analyzer": "id_index",
             "search_analyzer": "id_search",
+            "analyzer": "id_search",
             "type": "string"
           },
           "search": {
@@ -115,6 +118,7 @@
             "index": "analyzed",
             "index_analyzer": "id_index",
             "search_analyzer": "id_search",
+            "analyzer": "id_search",
             "type": "string"
           },
           "search": {

--- a/dcc-release-resources/src/main/resources/org/icgc/dcc/release/resources/mappings/project.mapping.json
+++ b/dcc-release-resources/src/main/resources/org/icgc/dcc/release/resources/mappings/project.mapping.json
@@ -1,7 +1,6 @@
 {
   "project":{
     "_source":{
-      "compress":"true"
     },
     "_all":{
       "enabled":"false"

--- a/dcc-release-resources/src/main/resources/org/icgc/dcc/release/resources/mappings/release.mapping.json
+++ b/dcc-release-resources/src/main/resources/org/icgc/dcc/release/resources/mappings/release.mapping.json
@@ -1,7 +1,6 @@
 {
   "release":{
     "_source":{
-      "compress":"true"
     },
     "_all":{
       "enabled":"false"

--- a/pom.xml
+++ b/pom.xml
@@ -279,6 +279,7 @@ ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF S
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
+      <version>19.0</version>
     </dependency>
     <dependency>
       <groupId>com.google.code.findbugs</groupId>


### PR DESCRIPTION
### Dependencies that needed to be upgraded:
- Guava -> 19.0
- Jackson Core -> 2.6+
### Things to watch out for
- FilterBuilders is no longer a thing, use QueryBuilders
- Cannot delete types anymore, you have to delete the index and recreate. 
- `search_analyzer` requires you to have an `analyzer` field as well. 

With these changes indexing _works_ but there are mapping issues that stop some types from being populated. 

@slovit I've created this branch for you to look at as a starting point for upgrading our elasticsearch. 
