### PR TITLE
Small fixes in preparation for upgrade of ES.

### DIFF
--- a/dcc-release-job/dcc-release-job-index/src/main/java/org/icgc/dcc/release/job/index/service/IndexVerificationService.java
+++ b/dcc-release-job/dcc-release-job-index/src/main/java/org/icgc/dcc/release/job/index/service/IndexVerificationService.java
@@ -17,22 +17,37 @@
  */
 package org.icgc.dcc.release.job.index.service;
 
-import com.google.common.collect.ImmutableSet;
-import lombok.NonNull;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-import lombok.val;
-import org.elasticsearch.client.Client;
-import org.icgc.dcc.common.core.util.Joiners;
-import org.icgc.dcc.release.core.document.DocumentType;
+import static java.lang.String.format;
+import static org.icgc.dcc.common.core.util.stream.Collectors.toImmutableList;
+import static org.icgc.dcc.common.core.util.stream.Collectors.toImmutableMap;
+import static org.icgc.dcc.release.core.document.DocumentType.DONOR_CENTRIC_TYPE;
+import static org.icgc.dcc.release.core.document.DocumentType.DONOR_TEXT_TYPE;
+import static org.icgc.dcc.release.core.document.DocumentType.DONOR_TYPE;
+import static org.icgc.dcc.release.core.document.DocumentType.DRUG_CENTRIC_TYPE;
+import static org.icgc.dcc.release.core.document.DocumentType.DRUG_TEXT_TYPE;
+import static org.icgc.dcc.release.core.document.DocumentType.GENE_CENTRIC_TYPE;
+import static org.icgc.dcc.release.core.document.DocumentType.GENE_SET_TEXT_TYPE;
+import static org.icgc.dcc.release.core.document.DocumentType.GENE_SET_TYPE;
+import static org.icgc.dcc.release.core.document.DocumentType.GENE_TEXT_TYPE;
+import static org.icgc.dcc.release.core.document.DocumentType.GENE_TYPE;
+import static org.icgc.dcc.release.core.document.DocumentType.MUTATION_CENTRIC_TYPE;
+import static org.icgc.dcc.release.core.document.DocumentType.MUTATION_TEXT_TYPE;
+import static org.icgc.dcc.release.core.document.DocumentType.PROJECT_TEXT_TYPE;
+import static org.icgc.dcc.release.core.document.DocumentType.PROJECT_TYPE;
 
 import java.util.Map;
 import java.util.Set;
 
-import static java.lang.String.format;
-import static org.icgc.dcc.common.core.util.stream.Collectors.toImmutableList;
-import static org.icgc.dcc.common.core.util.stream.Collectors.toImmutableMap;
-import static org.icgc.dcc.release.core.document.DocumentType.*;
+import org.elasticsearch.client.Client;
+import org.icgc.dcc.common.core.util.Joiners;
+import org.icgc.dcc.release.core.document.DocumentType;
+
+import com.google.common.collect.ImmutableSet;
+
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.val;
+import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @RequiredArgsConstructor

--- a/dcc-release-job/dcc-release-job-index/src/main/java/org/icgc/dcc/release/job/index/service/IndexVerificationService.java
+++ b/dcc-release-job/dcc-release-job-index/src/main/java/org/icgc/dcc/release/job/index/service/IndexVerificationService.java
@@ -17,36 +17,22 @@
  */
 package org.icgc.dcc.release.job.index.service;
 
-import static java.lang.String.format;
-import static org.icgc.dcc.common.core.util.stream.Collectors.toImmutableList;
-import static org.icgc.dcc.common.core.util.stream.Collectors.toImmutableMap;
-import static org.icgc.dcc.release.core.document.DocumentType.DONOR_CENTRIC_TYPE;
-import static org.icgc.dcc.release.core.document.DocumentType.DONOR_TEXT_TYPE;
-import static org.icgc.dcc.release.core.document.DocumentType.DONOR_TYPE;
-import static org.icgc.dcc.release.core.document.DocumentType.DRUG_CENTRIC_TYPE;
-import static org.icgc.dcc.release.core.document.DocumentType.DRUG_TEXT_TYPE;
-import static org.icgc.dcc.release.core.document.DocumentType.GENE_CENTRIC_TYPE;
-import static org.icgc.dcc.release.core.document.DocumentType.GENE_SET_TEXT_TYPE;
-import static org.icgc.dcc.release.core.document.DocumentType.GENE_SET_TYPE;
-import static org.icgc.dcc.release.core.document.DocumentType.GENE_TEXT_TYPE;
-import static org.icgc.dcc.release.core.document.DocumentType.GENE_TYPE;
-import static org.icgc.dcc.release.core.document.DocumentType.MUTATION_CENTRIC_TYPE;
-import static org.icgc.dcc.release.core.document.DocumentType.MUTATION_TEXT_TYPE;
-import static org.icgc.dcc.release.core.document.DocumentType.PROJECT_TEXT_TYPE;
-import static org.icgc.dcc.release.core.document.DocumentType.PROJECT_TYPE;
+import com.google.common.collect.ImmutableSet;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import lombok.val;
+import org.elasticsearch.client.Client;
+import org.icgc.dcc.common.core.util.Joiners;
+import org.icgc.dcc.release.core.document.DocumentType;
 
 import java.util.Map;
 import java.util.Set;
 
-import lombok.NonNull;
-import lombok.RequiredArgsConstructor;
-import lombok.val;
-import lombok.extern.slf4j.Slf4j;
-
-import org.elasticsearch.client.Client;
-import org.elasticsearch.common.collect.ImmutableSet;
-import org.icgc.dcc.common.core.util.Joiners;
-import org.icgc.dcc.release.core.document.DocumentType;
+import static java.lang.String.format;
+import static org.icgc.dcc.common.core.util.stream.Collectors.toImmutableList;
+import static org.icgc.dcc.common.core.util.stream.Collectors.toImmutableMap;
+import static org.icgc.dcc.release.core.document.DocumentType.*;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -72,7 +58,7 @@ public class IndexVerificationService {
 
   private void verifyGroupCounts(Set<DocumentType> typesGroup) {
     val groupCounts = typesGroup.stream()
-        .collect(toImmutableMap(type -> type, type -> getTypeCount(type)));
+        .collect(toImmutableMap(type -> type, this::getTypeCount));
 
     val sampleCount = groupCounts.values().iterator().next();
     val allEqual = groupCounts.values().stream()
@@ -97,7 +83,7 @@ public class IndexVerificationService {
 
   private static String getTypes(Set<DocumentType> types) {
     val typeNames = types.stream()
-        .map(type -> type.getName())
+        .map(DocumentType::getName)
         .collect(toImmutableList());
 
     return Joiners.COMMA.join(typeNames);

--- a/dcc-release-resources/src/main/resources/org/icgc/dcc/release/resources/mappings/diagram.mapping.json
+++ b/dcc-release-resources/src/main/resources/org/icgc/dcc/release/resources/mappings/diagram.mapping.json
@@ -2,7 +2,6 @@
   "diagram":{
     "enabled":false,
     "_source":{
-      "compress":"true"
     },
     "_all":{
       "enabled":"false"

--- a/dcc-release-resources/src/main/resources/org/icgc/dcc/release/resources/mappings/donor-centric.mapping.json
+++ b/dcc-release-resources/src/main/resources/org/icgc/dcc/release/resources/mappings/donor-centric.mapping.json
@@ -1,7 +1,6 @@
 {
   "donor-centric":{
     "_source":{
-      "compress":"true",
       "excludes": ["gene.*"]
     },
     "_all":{

--- a/dcc-release-resources/src/main/resources/org/icgc/dcc/release/resources/mappings/donor-text.mapping.json
+++ b/dcc-release-resources/src/main/resources/org/icgc/dcc/release/resources/mappings/donor-text.mapping.json
@@ -4,7 +4,6 @@
       "enabled": "false"
     },
     "_source": {
-      "compress": "true"
     },
     "date_detection": "false",
     "dynamic_templates": [

--- a/dcc-release-resources/src/main/resources/org/icgc/dcc/release/resources/mappings/donor.mapping.json
+++ b/dcc-release-resources/src/main/resources/org/icgc/dcc/release/resources/mappings/donor.mapping.json
@@ -1,7 +1,6 @@
 {
   "donor":{
     "_source":{
-      "compress":"true"
     },
     "_all":{
       "enabled":"false"

--- a/dcc-release-resources/src/main/resources/org/icgc/dcc/release/resources/mappings/drug-centric.mapping.json
+++ b/dcc-release-resources/src/main/resources/org/icgc/dcc/release/resources/mappings/drug-centric.mapping.json
@@ -1,7 +1,6 @@
 {
   "drug-centric": {
     "_source": {
-      "compress": "true"
     },
     "_all": {
       "enabled": "false"

--- a/dcc-release-resources/src/main/resources/org/icgc/dcc/release/resources/mappings/drug-text.mapping.json
+++ b/dcc-release-resources/src/main/resources/org/icgc/dcc/release/resources/mappings/drug-text.mapping.json
@@ -4,7 +4,6 @@
       "enabled": "false"
     },
     "_source": {
-      "compress": "true"
     },
     "date_detection": "false",
     "dynamic_templates": [

--- a/dcc-release-resources/src/main/resources/org/icgc/dcc/release/resources/mappings/gene-centric.mapping.json
+++ b/dcc-release-resources/src/main/resources/org/icgc/dcc/release/resources/mappings/gene-centric.mapping.json
@@ -4,7 +4,6 @@
       "enabled": "false"
     },
     "_source": {
-      "compress": "true",
       "includes": [
           "_gene_id",
           "_summary._affected_donor_count",

--- a/dcc-release-resources/src/main/resources/org/icgc/dcc/release/resources/mappings/gene-set-text.mapping.json
+++ b/dcc-release-resources/src/main/resources/org/icgc/dcc/release/resources/mappings/gene-set-text.mapping.json
@@ -4,7 +4,6 @@
       "enabled": "false"
     },
     "_source": {
-      "compress": "true"
     },
     "date_detection": "false",
     "dynamic_templates": [

--- a/dcc-release-resources/src/main/resources/org/icgc/dcc/release/resources/mappings/gene-set.mapping.json
+++ b/dcc-release-resources/src/main/resources/org/icgc/dcc/release/resources/mappings/gene-set.mapping.json
@@ -1,7 +1,6 @@
 {
   "gene-set": {
     "_source": {
-      "compress": "true"
     },
     "_all": {
       "enabled": "false"

--- a/dcc-release-resources/src/main/resources/org/icgc/dcc/release/resources/mappings/gene-text.mapping.json
+++ b/dcc-release-resources/src/main/resources/org/icgc/dcc/release/resources/mappings/gene-text.mapping.json
@@ -4,7 +4,6 @@
       "enabled": "false"
     },
     "_source": {
-      "compress": "true"
     },
     "date_detection": "false",
     "dynamic_templates": [

--- a/dcc-release-resources/src/main/resources/org/icgc/dcc/release/resources/mappings/gene.mapping.json
+++ b/dcc-release-resources/src/main/resources/org/icgc/dcc/release/resources/mappings/gene.mapping.json
@@ -2,7 +2,6 @@
   "gene":{
     "enabled":"false",
     "_source":{
-      "compress":"true"
     },
     "_all":{
       "enabled":"false"

--- a/dcc-release-resources/src/main/resources/org/icgc/dcc/release/resources/mappings/mutation-centric.mapping.json
+++ b/dcc-release-resources/src/main/resources/org/icgc/dcc/release/resources/mappings/mutation-centric.mapping.json
@@ -1,7 +1,6 @@
 {
   "mutation-centric":{
     "_source":{
-      "compress":"true"
     },
     "_all":{
       "enabled":"false"

--- a/dcc-release-resources/src/main/resources/org/icgc/dcc/release/resources/mappings/mutation-text.mapping.json
+++ b/dcc-release-resources/src/main/resources/org/icgc/dcc/release/resources/mappings/mutation-text.mapping.json
@@ -4,7 +4,6 @@
       "enabled": "false"
     },
     "_source": {
-      "compress": "true"
     },
     "date_detection": "false",
     "dynamic_templates": [

--- a/dcc-release-resources/src/main/resources/org/icgc/dcc/release/resources/mappings/observation-centric.mapping.json
+++ b/dcc-release-resources/src/main/resources/org/icgc/dcc/release/resources/mappings/observation-centric.mapping.json
@@ -1,7 +1,6 @@
 {
   "observation-centric": {
     "_source": {
-      "compress": "true",
       "excludes": [
         "project.primary_site",
         "donor.donor_sex",

--- a/dcc-release-resources/src/main/resources/org/icgc/dcc/release/resources/mappings/project-text.mapping.json
+++ b/dcc-release-resources/src/main/resources/org/icgc/dcc/release/resources/mappings/project-text.mapping.json
@@ -4,7 +4,6 @@
       "enabled": "false"
     },
     "_source": {
-      "compress": "true"
     },
     "date_detection": "false",
     "dynamic_templates": [

--- a/dcc-release-resources/src/main/resources/org/icgc/dcc/release/resources/mappings/project.mapping.json
+++ b/dcc-release-resources/src/main/resources/org/icgc/dcc/release/resources/mappings/project.mapping.json
@@ -1,7 +1,6 @@
 {
   "project":{
     "_source":{
-      "compress":"true"
     },
     "_all":{
       "enabled":"false"

--- a/dcc-release-resources/src/main/resources/org/icgc/dcc/release/resources/mappings/release.mapping.json
+++ b/dcc-release-resources/src/main/resources/org/icgc/dcc/release/resources/mappings/release.mapping.json
@@ -1,7 +1,6 @@
 {
   "release":{
     "_source":{
-      "compress":"true"
     },
     "_all":{
       "enabled":"false"


### PR DESCRIPTION
- `org.elasticsearch.common.collect.ImmutableSet` -> `com.google.common.collect.ImmutableSet`
- Removed `compress:true`
- method references are cool
